### PR TITLE
Refatorando CRUD de Comentário

### DIFF
--- a/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
+++ b/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
@@ -52,7 +52,7 @@ public class CommentController {
     public ResponseEntity<List<CommentResponse>> getAllCommentsAnswer(@PathVariable Long answerId){
         List<Comment> comments = this.commentService.getAllCommentsAnswer(answerId);
         List<CommentResponse> commentsResponse = comments.stream()
-                .map(a -> commentMapper.fromComment(a))
+                .map(comment -> commentMapper.fromComment(comment))
                 .collect(Collectors.toList());
         return new ResponseEntity<>(commentsResponse,HttpStatus.OK);
 
@@ -69,7 +69,7 @@ public class CommentController {
     public ResponseEntity<List<CommentResponse>> getAllCommentsQuestion(@PathVariable    Long questionId){
         List<Comment> comments = this.commentService.getAllCommentsQuestion(questionId);
         List<CommentResponse> commentsResponse = comments.stream()
-                .map(a -> commentMapper.fromComment(a))
+                .map(comment -> commentMapper.fromComment(comment))
                 .collect(Collectors.toList());
         return new ResponseEntity<>(commentsResponse,HttpStatus.OK);
     }

--- a/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
+++ b/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/comments")
@@ -41,28 +42,36 @@ public class CommentController {
         return new ResponseEntity<>(commentResponse, HttpStatus.CREATED);
     }
     @GetMapping("{commentId}/answers/{answerId}")
-    public ResponseEntity<Comment> getCommentAnswer(@PathVariable Long commentId, @PathVariable Long answerId){
+    public ResponseEntity<CommentResponse> getCommentAnswer(@PathVariable Long commentId, @PathVariable Long answerId){
         Comment commentResult = this.commentService.getCommentAnswer(commentId, answerId);
-        return new ResponseEntity<>(commentResult, HttpStatus.OK);
+        CommentResponse commentResponse = commentMapper.fromComment(commentResult);
+        return new ResponseEntity<>(commentResponse, HttpStatus.OK);
     }
 
     @GetMapping("/answers/{answerId}")
-    public ResponseEntity<List<Comment>> getAllCommentsAnswer(@PathVariable Long answerId){
+    public ResponseEntity<List<CommentResponse>> getAllCommentsAnswer(@PathVariable Long answerId){
         List<Comment> comments = this.commentService.getAllCommentsAnswer(answerId);
-        return new ResponseEntity<>(comments,HttpStatus.OK);
+        List<CommentResponse> commentsResponse = comments.stream()
+                .map(a -> commentMapper.fromComment(a))
+                .collect(Collectors.toList());
+        return new ResponseEntity<>(commentsResponse,HttpStatus.OK);
 
     }
 
     @GetMapping("{commentId}/questions/{questionId}")
-    public ResponseEntity<Comment> getCommentQuestion(@PathVariable Long commentId, @PathVariable   Long questionId){
+    public ResponseEntity<CommentResponse> getCommentQuestion(@PathVariable Long commentId, @PathVariable   Long questionId){
         Comment commentResult = this.commentService.getCommentQuestion(commentId, questionId);
-        return new ResponseEntity<>(commentResult, HttpStatus.OK);
+        CommentResponse commentResponse = commentMapper.fromComment(commentResult);
+        return new ResponseEntity<>(commentResponse, HttpStatus.OK);
     }
 
     @GetMapping("/questions/{questionId}")
-    public ResponseEntity<List<Comment>> getAllCommentsQuestion(@PathVariable    Long questionId){
+    public ResponseEntity<List<CommentResponse>> getAllCommentsQuestion(@PathVariable    Long questionId){
         List<Comment> comments = this.commentService.getAllCommentsQuestion(questionId);
-        return new ResponseEntity<>(comments,HttpStatus.OK);
+        List<CommentResponse> commentsResponse = comments.stream()
+                .map(a -> commentMapper.fromComment(a))
+                .collect(Collectors.toList());
+        return new ResponseEntity<>(commentsResponse,HttpStatus.OK);
     }
 
     @DeleteMapping("{commentId}/answers/{answerId}")

--- a/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
+++ b/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
@@ -87,14 +87,18 @@ public class CommentController {
     }
 
     @PutMapping("{commentId}/questions/{questionId}")
-    public ResponseEntity<Comment> updateCommentQuestion(@RequestBody CommentRequest comment, @PathVariable Long commentId, @PathVariable   Long questionId){
+    public ResponseEntity<CommentResponse> updateCommentQuestion(@RequestBody CommentRequest commentRequest, @PathVariable Long commentId, @PathVariable   Long questionId){
+        Comment comment = this.commentMapper.toCommentPUT(commentRequest);
         Comment commentResult = this.commentService.updateCommentQuestion(comment, commentId, questionId);
-        return new ResponseEntity<>(commentResult, HttpStatus.OK);
+        CommentResponse commentResponse = commentMapper.fromComment(commentResult);
+        return new ResponseEntity<>(commentResponse, HttpStatus.OK);
     }
 
     @PutMapping("{commentId}/answers/{answerId}")
-    public ResponseEntity<Comment> updateCommentAnswer(@RequestBody CommentRequest commentDTO, @PathVariable Long commentId, @PathVariable Long answerId){
-        Comment commentResult = this.commentService.updateCommentAnswer(commentDTO, commentId, answerId);
-        return new ResponseEntity<>(commentResult, HttpStatus.OK);
+    public ResponseEntity<CommentResponse> updateCommentAnswer(@RequestBody CommentRequest commentRequest, @PathVariable Long commentId, @PathVariable Long answerId){
+        Comment comment = this.commentMapper.toCommentPUT(commentRequest);
+        Comment commentResult = this.commentService.updateCommentAnswer(comment, commentId, answerId);
+        CommentResponse commentResponse = commentMapper.fromComment(commentResult);
+        return new ResponseEntity<>(commentResponse, HttpStatus.OK);
     }
 }

--- a/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
+++ b/ufcg/src/main/java/br/com/askufcg/controllers/CommentController.java
@@ -1,8 +1,14 @@
 package br.com.askufcg.controllers;
 
-import br.com.askufcg.dtos.comment.PostCommentDTO;
+import br.com.askufcg.dtos.answer.AnswerResponse;
+import br.com.askufcg.dtos.comment.CommentMapper;
+import br.com.askufcg.dtos.comment.CommentRequest;
+import br.com.askufcg.dtos.comment.CommentResponse;
+import br.com.askufcg.models.Answer;
 import br.com.askufcg.models.Comment;
+import br.com.askufcg.models.User;
 import br.com.askufcg.services.comment.CommentService;
+import br.com.askufcg.services.user.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,17 +22,23 @@ import java.util.List;
 public class CommentController {
     @Autowired
     private CommentService commentService;
+    @Autowired
+    private CommentMapper commentMapper;
 
     @PostMapping("/answers/{answerId}/users/{userId}")
-    public ResponseEntity<Comment> addCommentAnswer(@RequestBody PostCommentDTO comment, @PathVariable Long userId, @PathVariable Long answerId){
+    public ResponseEntity<CommentResponse> addCommentAnswer(@RequestBody CommentRequest commentRequest, @PathVariable Long userId, @PathVariable Long answerId){
+        Comment comment = commentMapper.toCommentPOST(commentRequest);
         Comment commentResult = this.commentService.addCommentAnswer(comment, userId, answerId);
-        return new ResponseEntity<>(commentResult, HttpStatus.CREATED);
+        CommentResponse commentResponse = commentMapper.fromComment(commentResult);
+        return new ResponseEntity<>(commentResponse, HttpStatus.CREATED);
     }
 
     @PostMapping("/questions/{questionId}/users/{userId}")
-    public  ResponseEntity<Comment> addCommentQuestion(@RequestBody PostCommentDTO comment, @PathVariable Long userId, @PathVariable     Long questionId){
-        Comment commentResult = this.commentService.addCommentQuestion(comment, userId, questionId);;
-        return new ResponseEntity<>(commentResult, HttpStatus.CREATED);
+    public  ResponseEntity<CommentResponse> addCommentQuestion(@RequestBody CommentRequest commentRequest, @PathVariable Long userId, @PathVariable     Long questionId){
+        Comment comment = commentMapper.toCommentPOST(commentRequest);
+        Comment commentResult = this.commentService.addCommentQuestion(comment, userId, questionId);
+        CommentResponse commentResponse = commentMapper.fromComment(commentResult);
+        return new ResponseEntity<>(commentResponse, HttpStatus.CREATED);
     }
     @GetMapping("{commentId}/answers/{answerId}")
     public ResponseEntity<Comment> getCommentAnswer(@PathVariable Long commentId, @PathVariable Long answerId){
@@ -66,13 +78,13 @@ public class CommentController {
     }
 
     @PutMapping("{commentId}/questions/{questionId}")
-    public ResponseEntity<Comment> updateCommentQuestion(@RequestBody PostCommentDTO comment, @PathVariable Long commentId, @PathVariable   Long questionId){
+    public ResponseEntity<Comment> updateCommentQuestion(@RequestBody CommentRequest comment, @PathVariable Long commentId, @PathVariable   Long questionId){
         Comment commentResult = this.commentService.updateCommentQuestion(comment, commentId, questionId);
         return new ResponseEntity<>(commentResult, HttpStatus.OK);
     }
 
     @PutMapping("{commentId}/answers/{answerId}")
-    public ResponseEntity<Comment> updateCommentAnswer(@RequestBody PostCommentDTO commentDTO, @PathVariable Long commentId, @PathVariable Long answerId){
+    public ResponseEntity<Comment> updateCommentAnswer(@RequestBody CommentRequest commentDTO, @PathVariable Long commentId, @PathVariable Long answerId){
         Comment commentResult = this.commentService.updateCommentAnswer(commentDTO, commentId, answerId);
         return new ResponseEntity<>(commentResult, HttpStatus.OK);
     }

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentMapper.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentMapper.java
@@ -1,18 +1,12 @@
 package br.com.askufcg.dtos.comment;
 
-import br.com.askufcg.dtos.user.UserMapper;
-import br.com.askufcg.dtos.user.UserResponse;
 import br.com.askufcg.models.Comment;
-import br.com.askufcg.models.User;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
 @Component
 public class CommentMapper {
-    @Autowired
-    private UserMapper userMapper;
     public Comment toCommentPOST(CommentRequest commentRequest){
         return Comment.builder()
                 .content(commentRequest.getContent())
@@ -21,12 +15,16 @@ public class CommentMapper {
     }
 
     public CommentResponse fromComment(Comment commentResult) {
-        var author = userMapper.fromUserToResponse(commentResult.getAuthor());
         return CommentResponse.builder()
                 .id(commentResult.getId())
                 .content(commentResult.getContent())
                 .createdAt(commentResult.getCreatedAt())
                 .author(commentResult.getAuthor())
+                .build();
+    }
+    public Comment toCommentPUT(CommentRequest commentRequest) {
+        return Comment.builder()
+               .content(commentRequest.getContent())
                 .build();
     }
 }

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentMapper.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentMapper.java
@@ -1,0 +1,32 @@
+package br.com.askufcg.dtos.comment;
+
+import br.com.askufcg.dtos.user.UserMapper;
+import br.com.askufcg.dtos.user.UserResponse;
+import br.com.askufcg.models.Comment;
+import br.com.askufcg.models.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class CommentMapper {
+    @Autowired
+    private UserMapper userMapper;
+    public Comment toCommentPOST(CommentRequest commentRequest){
+        return Comment.builder()
+                .content(commentRequest.getContent())
+                .createdAt(new Date())
+                .build();
+    }
+
+    public CommentResponse fromComment(Comment commentResult) {
+        var author = userMapper.fromUserToResponse(commentResult.getAuthor());
+        return CommentResponse.builder()
+                .id(commentResult.getId())
+                .content(commentResult.getContent())
+                .createdAt(commentResult.getCreatedAt())
+                .author(commentResult.getAuthor())
+                .build();
+    }
+}

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentMapper.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentMapper.java
@@ -1,12 +1,18 @@
 package br.com.askufcg.dtos.comment;
 
+import br.com.askufcg.dtos.user.UserMapper;
+import br.com.askufcg.dtos.user.UserResponse;
 import br.com.askufcg.models.Comment;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
 @Component
 public class CommentMapper {
+    @Autowired
+    private UserMapper userMapper;
+
     public Comment toCommentPOST(CommentRequest commentRequest){
         return Comment.builder()
                 .content(commentRequest.getContent())
@@ -15,11 +21,12 @@ public class CommentMapper {
     }
 
     public CommentResponse fromComment(Comment commentResult) {
+        UserResponse author = userMapper.fromUserToResponse(commentResult.getAuthor());
         return CommentResponse.builder()
                 .id(commentResult.getId())
                 .content(commentResult.getContent())
                 .createdAt(commentResult.getCreatedAt())
-                .author(commentResult.getAuthor())
+                .author(author)
                 .build();
     }
     public Comment toCommentPUT(CommentRequest commentRequest) {

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentRequest.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentRequest.java
@@ -3,6 +3,6 @@ package br.com.askufcg.dtos.comment;
 import lombok.Data;
 
 @Data
-public class PostCommentDTO {
+public class CommentRequest {
     private String content;
 }

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentResponse.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentResponse.java
@@ -1,6 +1,6 @@
 package br.com.askufcg.dtos.comment;
 
-import br.com.askufcg.models.User;
+import br.com.askufcg.dtos.user.UserResponse;
 import lombok.Builder;
 import lombok.Data;
 
@@ -12,5 +12,5 @@ public class CommentResponse {
     private Long id;
     private String content;
     private Date createdAt;
-    private User author;
+    private UserResponse author;
 }

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentResponse.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentResponse.java
@@ -4,7 +4,6 @@ import br.com.askufcg.models.User;
 import lombok.Builder;
 import lombok.Data;
 
-import javax.persistence.ManyToOne;
 import java.util.Date;
 
 @Data

--- a/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentResponse.java
+++ b/ufcg/src/main/java/br/com/askufcg/dtos/comment/CommentResponse.java
@@ -1,0 +1,17 @@
+package br.com.askufcg.dtos.comment;
+
+import br.com.askufcg.models.User;
+import lombok.Builder;
+import lombok.Data;
+
+import javax.persistence.ManyToOne;
+import java.util.Date;
+
+@Data
+@Builder
+public class CommentResponse {
+    private Long id;
+    private String content;
+    private Date createdAt;
+    private User author;
+}

--- a/ufcg/src/main/java/br/com/askufcg/services/comment/CommentService.java
+++ b/ufcg/src/main/java/br/com/askufcg/services/comment/CommentService.java
@@ -1,19 +1,20 @@
 package br.com.askufcg.services.comment;
 
-import br.com.askufcg.dtos.comment.PostCommentDTO;
+import br.com.askufcg.dtos.comment.CommentRequest;
 import br.com.askufcg.models.Comment;
+import br.com.askufcg.models.User;
 
 import java.util.List;
 
 public interface CommentService {
-     Comment addCommentAnswer(PostCommentDTO comment, Long userId, Long answerId);
-     Comment addCommentQuestion(PostCommentDTO comment, Long userId, Long questionId);
+     Comment addCommentAnswer(Comment comment, Long userId, Long answerId);
+     Comment addCommentQuestion(Comment comment, Long userId, Long questionId);
      Comment getCommentAnswer(Long commentId, Long answerid);
      List<Comment> getAllCommentsAnswer(Long answerId);
      Comment getCommentQuestion(Long commentId, Long questionId);
      List<Comment> getAllCommentsQuestion(Long questionId);
      Comment deleteCommentAnswer(Long commentId, Long answerId);
      Comment deleteCommentQuestion(Long commentId, Long questionId);
-     Comment updateCommentQuestion(PostCommentDTO comment, Long commentId, Long questionId);
-     Comment updateCommentAnswer(PostCommentDTO commentDTO, Long commentId, Long answerId);
+     Comment updateCommentQuestion(CommentRequest comment, Long commentId, Long questionId);
+     Comment updateCommentAnswer(CommentRequest commentDTO, Long commentId, Long answerId);
 }

--- a/ufcg/src/main/java/br/com/askufcg/services/comment/CommentService.java
+++ b/ufcg/src/main/java/br/com/askufcg/services/comment/CommentService.java
@@ -15,6 +15,6 @@ public interface CommentService {
      List<Comment> getAllCommentsQuestion(Long questionId);
      Comment deleteCommentAnswer(Long commentId, Long answerId);
      Comment deleteCommentQuestion(Long commentId, Long questionId);
-     Comment updateCommentQuestion(CommentRequest comment, Long commentId, Long questionId);
-     Comment updateCommentAnswer(CommentRequest commentDTO, Long commentId, Long answerId);
+     Comment updateCommentQuestion(Comment comment, Long commentId, Long questionId);
+     Comment updateCommentAnswer(Comment commentDTO, Long commentId, Long answerId);
 }

--- a/ufcg/src/main/java/br/com/askufcg/services/comment/CommentService.java
+++ b/ufcg/src/main/java/br/com/askufcg/services/comment/CommentService.java
@@ -16,5 +16,5 @@ public interface CommentService {
      Comment deleteCommentAnswer(Long commentId, Long answerId);
      Comment deleteCommentQuestion(Long commentId, Long questionId);
      Comment updateCommentQuestion(Comment comment, Long commentId, Long questionId);
-     Comment updateCommentAnswer(Comment commentDTO, Long commentId, Long answerId);
+     Comment updateCommentAnswer(Comment comment, Long commentId, Long answerId);
 }

--- a/ufcg/src/main/java/br/com/askufcg/services/comment/CommentServiceImpl.java
+++ b/ufcg/src/main/java/br/com/askufcg/services/comment/CommentServiceImpl.java
@@ -1,6 +1,6 @@
 package br.com.askufcg.services.comment;
 
-import br.com.askufcg.dtos.comment.PostCommentDTO;
+import br.com.askufcg.dtos.comment.CommentRequest;
 import br.com.askufcg.exceptions.NotFoundException;
 import br.com.askufcg.models.Answer;
 import br.com.askufcg.models.Comment;
@@ -30,30 +30,34 @@ public class CommentServiceImpl implements CommentService {
     @Autowired
     private AnswerRepository answerRepository;
 
-    public Comment addCommentAnswer(PostCommentDTO postCommentDTO, Long userId, Long answerId) {
+    public Comment addCommentAnswer(Comment comment, Long userId, Long answerId) {
         Optional<User> user = userRepository.findById(userId);
         checkEntityNotFound(user, "User not found.");
 
         Optional<Answer> answer = answerRepository.findById(answerId);
         checkEntityNotFound(answer, "Answer not found.");
 
-        Comment commentReturn = saveComment(user.get(), postCommentDTO.getContent());
-        saveCommentInAnswer(answer.get(), commentReturn);
+        User author = user.get();
+        comment.setAuthor(author);
+        commentRepository.save(comment);
+        saveCommentInAnswer(answer.get(), comment);
 
-        return commentReturn;
+        return comment;
     }
 
-    public Comment addCommentQuestion(PostCommentDTO postCommentDTO, Long userId, Long questionId) {
+    public Comment addCommentQuestion(Comment comment, Long userId, Long questionId) {
         Optional<User> user = userRepository.findById(userId);
         checkEntityNotFound(user, "User not found.");
 
         Optional<Question> question = questionRepository.findById(questionId);
         checkEntityNotFound(question, "Question not found.");
 
-        Comment commentReturn = saveComment(user.get(), postCommentDTO.getContent());
-        saveCommentInQuestion(question.get(), commentReturn);
+        User author = user.get();
+        comment.setAuthor(author);
+        commentRepository.save(comment);
+        saveCommentInQuestion(question.get(), comment);
 
-        return commentReturn;
+        return comment;
     }
 
     public Comment getCommentAnswer(Long commentId, Long answerId) {
@@ -127,7 +131,7 @@ public class CommentServiceImpl implements CommentService {
         return comment;
     }
 
-    public Comment updateCommentQuestion(PostCommentDTO commentDTO, Long commentId, Long questionId) {
+    public Comment updateCommentQuestion(CommentRequest commentDTO, Long commentId, Long questionId) {
         checkCommentAndQuestion(commentId, questionId);
 
         Comment comment = commentRepository.findById(commentId).get();
@@ -141,7 +145,7 @@ public class CommentServiceImpl implements CommentService {
 
     }
 
-    public Comment updateCommentAnswer(PostCommentDTO commentDTO, Long commentId, Long answerId) {
+    public Comment updateCommentAnswer(CommentRequest commentDTO, Long commentId, Long answerId) {
         checkCommentAndAnswer(commentId, answerId);
 
         Comment comment = commentRepository.findById(commentId).get();

--- a/ufcg/src/main/java/br/com/askufcg/services/comment/CommentServiceImpl.java
+++ b/ufcg/src/main/java/br/com/askufcg/services/comment/CommentServiceImpl.java
@@ -1,6 +1,5 @@
 package br.com.askufcg.services.comment;
 
-import br.com.askufcg.dtos.comment.CommentRequest;
 import br.com.askufcg.exceptions.NotFoundException;
 import br.com.askufcg.models.Answer;
 import br.com.askufcg.models.Comment;
@@ -131,40 +130,29 @@ public class CommentServiceImpl implements CommentService {
         return comment;
     }
 
-    public Comment updateCommentQuestion(CommentRequest commentDTO, Long commentId, Long questionId) {
+    public Comment updateCommentQuestion(Comment comment, Long commentId, Long questionId) {
         checkCommentAndQuestion(commentId, questionId);
 
-        Comment comment = commentRepository.findById(commentId).get();
+        Comment originalComment = commentRepository.findById(commentId).get();
         Question question = questionRepository.findById(questionId).get();
 
-        comment.setContent(commentDTO.getContent());
-        comment.setCreatedAt(new Date());
-        commentRepository.save(comment);
+        originalComment.setContent(comment.getContent());
+        commentRepository.save(originalComment);
         questionRepository.save(question);
-        return comment;
+        return originalComment;
 
     }
 
-    public Comment updateCommentAnswer(CommentRequest commentDTO, Long commentId, Long answerId) {
+    public Comment updateCommentAnswer(Comment comment, Long commentId, Long answerId) {
         checkCommentAndAnswer(commentId, answerId);
 
-        Comment comment = commentRepository.findById(commentId).get();
+        Comment originalComment = commentRepository.findById(commentId).get();
         Answer answer = answerRepository.findById(answerId).get();
 
-        comment.setContent(commentDTO.getContent());
-        comment.setCreatedAt(new Date());
-        commentRepository.save(comment);
+        originalComment.setContent(comment.getContent());
+        commentRepository.save(originalComment);
         answerRepository.save(answer);
-        return comment;
-    }
-
-    private Comment  saveComment(User user, String content){
-        Comment comment = new Comment();
-        comment.setAuthor(user);
-        comment.setCreatedAt(new Date());
-        comment.setContent(content);
-
-        return commentRepository.save(comment);
+        return originalComment;
     }
 
     private void saveCommentInAnswer(Answer answer, Comment comment){


### PR DESCRIPTION
Readequando minha issue ao padrão proposto por @wellissongomes.

- Anteriormente eu modelei os UPDATEs de forma que a data do comentário alterado fosse atualizada. Ao refatorar, percebi que isso não faz sentido, devendo manter a data de criação do comentário independente de ele ser alterado.